### PR TITLE
Refactor: AdminReservation 컨트롤러 응답 방식 및 오타  수정

### DIFF
--- a/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
@@ -14,13 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.groomiz.billage.global.anotation.ApiErrorExceptionsExample;
-import com.groomiz.billage.reservation.document.AdminApproveRejectExceptionDocs;
-import com.groomiz.billage.reservation.document.AdminReservationDeleteExceptionDocs;
-import com.groomiz.billage.reservation.document.AdminReservationExceptionDocs;
-import com.groomiz.billage.reservation.document.AdminSearchExceptionDocs;
-import com.groomiz.billage.reservation.document.AdminbyStatusExceptionDocs;
 import com.groomiz.billage.reservation.dto.request.AdminReservationRequest;
+import com.groomiz.billage.reservation.dto.response.AdminReservationResponse;
 import com.groomiz.billage.reservation.dto.response.AdminReservationStatusListResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,7 +30,6 @@ public class AdminReservationController {
 
 	@GetMapping
 	@Operation(summary = "예약 상태별 리스트 조회")
-	@ApiErrorExceptionsExample(AdminbyStatusExceptionDocs.class)
 	public ResponseEntity<List<AdminReservationStatusListResponse>> getReservationsByStatus(
 		@RequestParam(required = false) String status) {
 		return ResponseEntity.ok(null);
@@ -43,7 +37,6 @@ public class AdminReservationController {
 
 	@PostMapping("/{id}/approve")
 	@Operation(summary = "예약 승인")
-	@ApiErrorExceptionsExample(AdminApproveRejectExceptionDocs.class)
 	public ResponseEntity<Map<String, String>> approveReservation(@PathVariable Long id) {
 		Map<String, String> response = new HashMap<>();
 		response.put("message", "예약 승인 되었습니다.");
@@ -52,7 +45,6 @@ public class AdminReservationController {
 
 	@PostMapping("/{id}/reject")
 	@Operation(summary = "예약 거절")
-	@ApiErrorExceptionsExample(AdminApproveRejectExceptionDocs.class)
 	public ResponseEntity<Map<String, String>> rejectReservation(@PathVariable Long id,
 		@RequestBody(required = false) String rejectionReason) {
 		Map<String, String> response = new HashMap<>();
@@ -65,26 +57,30 @@ public class AdminReservationController {
 
 	@PostMapping
 	@Operation(summary = "예약 요청 처리")
-	@ApiErrorExceptionsExample(AdminReservationExceptionDocs.class)
-	public ResponseEntity<?> createReservation(
+	public ResponseEntity<Map<String, String>> createReservation(
 		@RequestBody AdminReservationRequest request) {
 
-		return ResponseEntity.ok().body("{\"message\": \"예약 완료 하였습니다.\"}");
+		Map<String, String> response = new HashMap<>();
+		response.put("message", "예약 완료 하였습니다.");
+
+		return ResponseEntity.ok(response);
 	}
 
-	@GetMapping("/{reservationId}")
+	@GetMapping("/{id}")
 	@Operation(summary = "예약 상세 조회")
-	@ApiErrorExceptionsExample(AdminSearchExceptionDocs.class)
-	public ResponseEntity<String> getReservation(@PathVariable Long reservationId) {
+	public ResponseEntity<AdminReservationResponse> getReservation(@PathVariable Long id) {
+
 		return ResponseEntity.ok(null);
 	}
 
 	@DeleteMapping("/{id}")
 	@Operation(summary = "예약 삭제", description = "단일 예약, 기간 예약, 반복 예약을 삭제합니다.")
-
-	@ApiErrorExceptionsExample(AdminReservationDeleteExceptionDocs.class)
-	public ResponseEntity<String> deleteReservation(@PathVariable Long id,
+	public ResponseEntity<Map<String, String>> deleteReservation(@PathVariable Long id,
 		@RequestParam(required = false, defaultValue = "single") String type) {
-		return ResponseEntity.ok(null);
+
+		Map<String, String> response = new HashMap<>();
+		response.put("message", "예약 삭제 하였습니다.");
+
+		return ResponseEntity.ok(response);
 	}
 }


### PR DESCRIPTION
## ✅ 풀\_리퀘스트 체크리스트

<!--
하나씩 확인 후 체크박스에 표시해주세요.
-->

- [x] PR 제목: [Feature/Fix/Refactor...] 작업 내용 한 줄 요약 (브랜치 이름) #이슈번호
- [x] commit message 가 적절한지 확인해주세요.
- [x] 적절한 branch 로 요청했는지 확인해주세요.
- [x] Assignees, Label 을 붙여주세요.
- [x] 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer 로 등록해주세요.
- [x] PR이 승인된 경우 해당 브랜치는 삭제해 주세요!

<br/>

## 🔄 변경 사항

* ResponseEntity<Map<String, String>>를 사용하여 Map을 반환하도록 createResponse 메소드를 변경하였습니다.
* 다 id라고 설정했는데 상세조회 파트만 reservationId라고 해놨어서 일관성을 위해 id라고 수정하였습니다.
* 예약 상세 조회에 String으로 해두고 dto로 안바꾼거 발견해서 수정했습니다.
* 삭제도 예약 요청 처리랑 응답값 똑같에서 똑같이 수정했습니다.

<br/>

## 📎 변경한 이유

- 이러한 이유 때문에 변경했습니다!

<br/>

<!-- 관련되어있는 Issue Number 를 작성하세요! 해당 이슈를 이곳에 적으면 pr merge 이후 해당 이슈는 자동으로 close 됩니다. -->

closes: #Issue Number

## 👨🏻‍💻 테스트 체크리스트

<!-- 테스트 사항이 있다면 작성해 주세요! -->

- 이러한 테스트를 했어요!

<br/>

## 📌 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 있다면 적어주세요.
주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 리뷰어로 등록해주세요. (다른 사람이 작성한 코드 수정 등)
코드 리뷰 시 더 꼼꼼하게 확인 받고 싶은 부분이 있다면 적어주세요.
-->

<br/>